### PR TITLE
Add support for Ollama integration across all tasks

### DIFF
--- a/netconfeval/common/model_configs.py
+++ b/netconfeval/common/model_configs.py
@@ -106,8 +106,60 @@ def _build_mistral_lite_prompt(messages):
 
     return prompt
 
+def _build_qwen2_prompt(messages):
+    
+    start_turn = "<|im_start|>"
+    end_turn = "<|im_end|>\n"
+ 
+
+    conversation = []
+    for index, message in enumerate(messages):
+        parts = message.split(": ", 1)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid message format: {message}")
+
+        role, content = parts
+        content = content.strip()
+
+        if role.lower() in ['user', 'system', 'assistant']:
+            conversation.append(start_turn + role.lower() + '\n' + content + end_turn) 
+        else:
+            raise ValueError(f"Unexpected role: {role}")
+
+   # Assemble the prompt with the start and end tokens and start the turn of assistant to prime the generation process
+    prompt = ' '.join(conversation) + start_turn + "assistant\n" 
+
+    return prompt 
+
+
+def _build_llama3_prompt(messages):
+    start_prompt = "<|begin_of_text|>"
+    start_role = "<|start_header_id|>"
+    end_role = "<|end_header_id|>"
+    end_turn = "<|eot_id|>"
+
+    conversation = []
+    for index, message in enumerate(messages):
+        parts = message.split(": ", 1)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid message format: {message}")
+
+        role, content = parts
+        content = content.strip()
+
+        if role.lower() in ['user', 'system', 'assistant']:
+            conversation.append(start_role + role.lower() + end_role + content + end_turn ) # Example: <|begin_of_text|><|start_header_id|>system<|end_header_id|>
+        else:
+            raise ValueError(f"Unexpected role: {role}")
+
+   # Assemble the prompt with the start and end tokens and start the turn of assistant to prime the generation process
+    prompt = start_prompt + ' '.join(conversation)  + '\n' + start_role + "assistant" + end_role
+    print(prompt)
+    return prompt
+
 
 def get_model_instance(model_name: str) -> Any:
+
     if model_configurations[model_name]['type'] == 'HF':
         from netconfeval.foundation.langchain.chat_models.hf import ChatHF
 
@@ -117,6 +169,15 @@ def get_model_instance(model_name: str) -> Any:
             use_quantization=model_configurations[model_name]['use_quantization'],
             prompt_func=model_configurations[model_name]['prompt_builder'],
         )
+    
+    elif model_configurations[model_name]['type'] == 'Ollama':
+        from langchain_community.llms import Ollama
+
+        return Ollama(model = model_configurations[model_name]['model_name'],
+                      num_predict = model_configurations[model_name]['num_predict'],
+                      num_gpu=-1
+                     )
+        
     elif model_configurations[model_name]['type'] == 'openai':
         from langchain_openai import ChatOpenAI
 
@@ -165,6 +226,74 @@ model_configurations = {
             'seed': 5000,
         }
     },
+
+    #### Start Ollama models ####
+
+    'llama3.1-ollama': {
+        'type': 'Ollama',
+        'model_name': 'llama3.1:8b-instruct-fp16',
+        'num_predict': 4096
+    },
+
+    'llama3-ollama': {
+        'type': 'Ollama',
+        'model_name': 'llama3:8b-instruct-fp16',
+        'num_predict': 4096
+    },
+
+    'neural-chat-ollama': {
+        'type': 'Ollama',
+        'model_name': 'neural-chat:7b-v3.3-fp16',
+        'num_predict': 4096
+    },
+
+    # 4-bit quantization version 
+
+    'llama3.1-4bit-ollama': {
+        'type': 'Ollama',
+        'model_name': 'llama3.1:latest',
+        'num_predict': 4096
+    },
+
+    'llama3-4bit-ollama': {
+        'type': 'Ollama',
+        'model_name': 'llama3:latest',
+        'num_predict': 4096
+    },
+      
+    'neural-chat-4bit-ollama': {
+        'type': 'Ollama',
+        'model_name': 'neural-chat:latest',
+        'num_predict': 4096
+    },
+
+    #### End Ollama models #####
+    
+
+    'qwen2.5-7b-instruct': {
+        'type': 'HF',
+        'model_name':'Qwen/Qwen2.5-7B-Instruct',
+        'prompt_builder': _build_qwen2_prompt,
+        'max_length': 4096,
+        'use_quantization': False
+    },
+
+    'llama3-8b-instruct': {
+        'type': 'HF',
+        'model_name': 'meta-llama/Meta-Llama-3-8B-Instruct',
+        'prompt_builder': _build_llama3_prompt,
+        'max_length': 4096,
+        'use_quantization': False
+    },
+
+    'llama3.1-8b-instruct': {
+        'type': 'HF',
+        'model_name': 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        'prompt_builder': _build_llama3_prompt,
+        'max_length': 4096,
+        'use_quantization': False
+    },
+
     'llama2-7b-chat': {
         'model_name': 'meta-llama/Llama-2-7b-chat-hf',
         'prompt_builder': _build_llama2_prompt,

--- a/netconfeval/step_1_formal_spec_conflict_detection.py
+++ b/netconfeval/step_1_formal_spec_conflict_detection.py
@@ -143,7 +143,7 @@ def main(args: argparse.Namespace) -> None:
 
                     skip_compare = False
                     start_time = time.time()
-                    if model_configurations[args.model]['type'] == 'HF':
+                    if model_configurations[args.model]['type'] in ['HF','Ollama']:
                         # Combine all system prompts with a new line separator
                         combined_system_prompt = f"{SETUP_PROMPT}\n{FUNCTION_PROMPT}\n{ASK_FOR_RESULT_PROMPT}"
                         messages = [

--- a/netconfeval/step_1_formal_spec_conflict_distance.py
+++ b/netconfeval/step_1_formal_spec_conflict_distance.py
@@ -137,7 +137,7 @@ def main(args: argparse.Namespace) -> None:
 
                             skip_compare = False
                             start_time = time.time()
-                            if model_configurations[args.model]['type'] == 'HF':
+                            if model_configurations[args.model]['type']  in ['HF','Ollama']:
                                 # Combine all system prompts with a new line separator
                                 combined_system_prompt = f"{SETUP_PROMPT}\n{FUNCTION_PROMPT}\n{ASK_FOR_RESULT_PROMPT}"
                                 messages = [

--- a/netconfeval/step_1_formal_spec_translation.py
+++ b/netconfeval/step_1_formal_spec_translation.py
@@ -135,7 +135,7 @@ def main(args: argparse.Namespace) -> None:
 
                     skip_compare = False
                     start_time = time.time()
-                    if model_configurations[args.model]['type'] == 'HF':
+                    if model_configurations[args.model]['type'] in ['HF','Ollama']:
                         # Combine all system prompts with a new line separator
                         combined_system_prompt = f"{SETUP_PROMPT}\n{FUNCTION_PROMPT}\n{ASK_FOR_RESULT_PROMPT}"
                         messages = [

--- a/netconfeval/step_2_code_gen.py
+++ b/netconfeval/step_2_code_gen.py
@@ -126,7 +126,7 @@ def main(args: argparse.Namespace) -> None:
                     w = csv.DictWriter(f, result_row.keys())
                     w.writeheader()
 
-                if model_configurations[args.model]['type'] == 'HF':
+                if model_configurations[args.model]['type'] in ['HF','Ollama']:
                     combined_system_prompt = f"{SETUP_PROMPT}\n{ASK_FOR_CODE_PROMPT}"
                     combined_human_prompt = f"{INPUT_OUTPUT_PROMPT}\n{INSTRUCTION_PROMPT}\n{{input}}"
                     if with_feedback:


### PR DESCRIPTION
This PR introduces support for using Ollama across all tasks. Additionally, the file netconfeval/common/model_configs.py has been extended with prompt builders for SOTA models like LLama3.1 and Qwen2.5 and the dictionary updated with Ollama models. These updates have been tested with positive outcomes.